### PR TITLE
Add user login flow

### DIFF
--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+  include SessionsHelper
+
+  private
+
+  def redirect_unless_logged_in
+    redirect_to login_path, flash: { danger: 'Please log in.' } unless logged_in?
+  end
+
+  def redirect_if_logged_in
+    redirect_to root_path, flash: { danger: 'You are already logged in.' } if logged_in?
+  end
 end

--- a/app/controllers/kalendar_controller.rb
+++ b/app/controllers/kalendar_controller.rb
@@ -1,3 +1,5 @@
 class KalendarController < ApplicationController
+  before_action :redirect_unless_logged_in
+
   def home; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,20 @@
+class SessionsController < ApplicationController
+  before_action :redirect_if_logged_in, only: [:new, :create]
+
+  def new; end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user&.authenticate(params[:session][:password])
+      log_in(user)
+      redirect_to root_path, flash: { success: 'Logged in successfully.' }
+    else
+      redirect_to login_path, flash: { danger: 'Invalid email/password combination.' }
+    end
+  end
+
+  def destroy
+    log_out
+    redirect_to login_path, flash: { success: 'Logged out successfully.' }
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :redirect_unless_logged_in, only: [:show]
+  before_action :redirect_if_logged_in, only: [:new, :create]
+
   def new
     @user = User.new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      log_in(@user)
       redirect_to @user, flash: { success: 'Your account has been successfully created.' }
     else
       render 'new'

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,18 @@
+module SessionsHelper
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def logged_in?
+    !current_user.nil?
+  end
+end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -11,6 +11,7 @@ $font-primary: 'Open Sans';
 /* Pages */
 @import 'users/new.scss';
 @import 'users/show.scss';
+@import 'sessions/new.scss';
 
 html, body {
   margin: 0;
@@ -18,6 +19,7 @@ html, body {
 }
 
 .navbar {
+  margin: 1rem;
   .navbar-brand {
     .navbar-item {
       span {

--- a/app/javascript/stylesheets/sessions/_new.scss
+++ b/app/javascript/stylesheets/sessions/_new.scss
@@ -1,0 +1,32 @@
+.authentication-fields {
+  margin: 3rem auto;
+  width: 450px;
+  h1 {
+    font: {
+      family: $font-primary;
+      weight: 800;
+    }
+    margin: {
+      top: 1rem;
+      bottom: 2rem;
+    }
+  }
+  .input {
+    margin: {
+      bottom: 0.5rem;
+    }
+  }
+  input.button {
+    display: block;
+    margin: {
+      top: 1rem;
+      left: auto;
+    }
+    font: {
+      weight: 600;
+    }
+  }
+  p{
+    margin-top: 1rem;
+  }
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,21 +1,32 @@
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
-    <a class="navbar-item is-size-3" href="/">
-      <span>Kalendar</span>
-    </a>
-
-    <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar">
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-    </a>
+    <% if logged_in? %>
+      <a class="navbar-item is-size-3" href="/">
+        <span>Kalendar</span>
+      </a>
+      <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </a>
+    <% else %>
+      <a class="navbar-item is-size-3" href="/login">
+        <span>Kalendar</span>
+      </a>
+    <% end %>
   </div>
 
   <div id="navbar" class="navbar-menu">
-    <div class="navbar-end">
-      <div class="navbar-item">
-        <!-- TODO: ログイン時に、ユーザーページへ飛ぶリンクを表示 -->
+    <% if logged_in?  %>
+      <div class="navbar-end">
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link">Accounts</a>
+          <div class="navbar-dropdown">
+            <%= link_to 'Settings', current_user, class: 'navbar-item' %>
+            <%= link_to 'Log out', logout_path, method: :delete, class: 'navbar-item' %>
+          </div>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </nav>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,15 @@
+<div class="authentication-fields">
+  <h1 class="has-text-centered is-size-3">Log in</h1>
+  <%= form_with( scope: :session, url: login_path, local: true ) do |f| %>
+
+    <%= f.label :email, class: 'label' %>
+    <%= f.email_field :email, class: 'input' %>
+
+    <%= f.label :password, class: 'label' %>
+    <%= f.password_field :password, class: 'input' %>
+
+    <%= f.submit "Log in", class: "button is-info" %>
+  <% end %>
+
+  <p class="has-text-right">New user? <%= link_to "Sign up now!", signup_url %></p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Rails.application.routes.draw do
   root to: 'kalendar#home'
 
-  # User Authentication
+  # User Registration
   get  '/signup', to: 'users#new'
   post '/signup', to: 'users#create'
+
+  # User Authentication
+  get    '/login',  to: 'sessions#new'
+  post   '/login',  to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
+
   resources :users
 end

--- a/spec/features/home_layout_spec.rb
+++ b/spec/features/home_layout_spec.rb
@@ -1,8 +1,0 @@
-require 'rails_helper'
-
-RSpec.feature 'Home page', type: :feature do
-  it do
-    visit '/'
-    expect(page).to have_text(Time.new.strftime('%B'))
-  end
-end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SessionsHelper, type: :helper do
   describe '#corrent_user' do
     context 'ログイン中のユーザーがいない時' do
       it 'nilを返す' do
-        expect(current_user.nil?).to be_truthy
+        expect(current_user).to be_nil
       end
     end
 

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SessionsHelper, type: :helper do
+  let(:user) { create(:user) }
+
+  describe '#corrent_user' do
+    context 'ログイン中のユーザーがいない時' do
+      it 'nilを返す' do
+        expect(current_user.nil?).to be_truthy
+      end
+    end
+
+    context 'ログイン中のユーザーがいる時' do
+      it '正しいユーザーを返す' do
+        log_in(user)
+        expect(current_user).to eq user
+      end
+    end
+  end
+end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SessionsHelper, type: :helper do
   let(:user) { create(:user) }
 
-  describe '#corrent_user' do
+  describe '#current_user' do
     context 'ログイン中のユーザーがいない時' do
       it 'nilを返す' do
         expect(current_user).to be_nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rspec'
 
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e

--- a/spec/requests/kalendar_request_spec.rb
+++ b/spec/requests/kalendar_request_spec.rb
@@ -1,10 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Kalendars', type: :request do
-  describe 'GET /home' do
-    it 'returns http success' do
-      get '/'
-      expect(response).to have_http_status(:ok)
+  describe 'GET /' do
+    let(:user) { create(:user) }
+
+    context 'when not logged in' do
+      it 'returns status 302' do
+        get '/'
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context 'when logged in' do
+      it 'returns status 200' do
+        log_in(user)
+        get '/'
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/requests/kalendar_request_spec.rb
+++ b/spec/requests/kalendar_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Kalendars', type: :request do
 
     context 'when logged in' do
       it 'returns status 200' do
-        log_in(user)
+        login(user)
         get '/'
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /login" do
+    it "returns http success" do
+      get "/login"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -1,15 +1,8 @@
-def log_in(user, options = {})
-  if options[:by_capybara]
-    visit login_path
-    fill_in "Email",    with: user.email
-    fill_in "Password", with: user.password
-    click_button 'Log in'
-  else
-    post login_path, params: {
-      session: {
-        email: user.email,
-        password: user.password
-      }
+def login(user)
+  post login_path, params: {
+    session: {
+      email: user.email,
+      password: user.password
     }
-  end
+  }
 end

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -1,0 +1,15 @@
+def log_in(user, options = {})
+  if options[:by_capybara]
+    visit login_path
+    fill_in "Email",    with: user.email
+    fill_in "Password", with: user.password
+    click_button 'Log in'
+  else
+    post login_path, params: {
+      session: {
+        email: user.email,
+        password: user.password
+      }
+    }
+  end
+end

--- a/spec/systems/users_login_spec.rb
+++ b/spec/systems/users_login_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'UsersLogin', type: :system do
+  let(:user) { create(:user) }
+
+  context 'アカウントが存在しない時' do
+    it '「Invalid email/password combination.」と表示される' do
+      visit login_path
+      fill_in 'Email',    with: 'nobody@example.com'
+      fill_in 'Password', with: 'piyopiyo'
+      click_button 'Log in'
+      expect(page).to have_content 'Invalid email/password combination.'
+    end
+  end
+
+  context 'ログインに成功した時' do
+    it '「Logged in successfully.」と表示され、/home にリダイレクトされる' do
+      visit login_path
+      fill_in 'Email',    with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log in'
+      expect(page).to have_content 'Logged in successfully.'
+      expect(current_path).to eq root_path
+    end
+
+    it 'ログアウトできる' do
+      visit login_path
+      fill_in 'Email',    with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log in'
+      find('.navbar-link').hover
+      click_link 'Log out'
+      expect(page).to have_content 'Logged out successfully.'
+    end
+  end
+end

--- a/spec/views/sessions/new.html.erb_spec.rb
+++ b/spec/views/sessions/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "sessions/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/sessions/new.html.erb_spec.rb
+++ b/spec/views/sessions/new.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "sessions/new.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
fixes #5 
fixes #6 

## 背景
- ユーザーが `/login` からサイトにログインできるようにしたい。
- ログイン状態によって、ヘッダーの情報や、閲覧できるページを制限したい

## やったこと
- [x] セッション管理用 Controller, View, Helper の作成
- [x] ログインページのデザイン調整
- [x] ユーザー登録後、自動でログインさせる
- [x] ログイン状態によってヘッダーに記載する情報を変える
- [x] ログイン中だと、 `/signup` , `/login` を閲覧できないようにした
- [x] テストの作成
- [x] 影響の出ているテストの修正

## やらないこと
- remember_login 機能


