### PR TITLE
Add Task model

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,3 @@
+class Task < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
+  validates :user_id, presence: true
+  validates :title, presence: true, length: { maximum: 20 }
+  validates :description, length: { maximum: 140 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
   validates :user_id, presence: true
-  validates :title, presence: true, length: { maximum: 20 }
-  validates :description, length: { maximum: 140 }
+  validates :title, presence: true, length: { maximum: 40 }
+  validates :description, length: { maximum: 255 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :tasks, dependent: :destroy
+
   before_save :downcase_email
 
   validates :name,  presence: true, length: { maximum: 50 }

--- a/db/migrate/20200505045339_create_tasks.rb
+++ b/db/migrate/20200505045339_create_tasks.rb
@@ -1,0 +1,13 @@
+class CreateTasks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tasks do |t|
+      t.string :title
+      t.text :description
+      t.string :start_at
+      t.string :finish_at
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_045339) do
+ActiveRecord::Schema.define(version: '2020_05_05_045339') do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: '2020_04_29_073422') do
+ActiveRecord::Schema.define(version: 2020_05_05_045339) do
+
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.string "start_at"
+    t.string "finish_at"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -20,4 +31,5 @@ ActiveRecord::Schema.define(version: '2020_04_29_073422') do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,9 +1,7 @@
 FactoryBot.define do
   factory :task do
-    title { "MyString" }
-    description { "MyText" }
-    start_at { "MyString" }
-    finish_at { "MyString" }
-    user { nil }
+    title       { Faker::Lorem.sentence(word_count: 2) }
+    description { Faker::Lorem.sentence(word_count: 10) }
+    association :user, factory: :user
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :task do
+    title { "MyString" }
+    description { "MyText" }
+    start_at { "MyString" }
+    finish_at { "MyString" }
+    user { nil }
+  end
+end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :task do
     title       { Faker::Lorem.sentence(word_count: 2) }
     description { Faker::Lorem.sentence(word_count: 10) }
-    association :user, factory: :user
+    user        { create(:user) }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:task) { create(:task, user: user) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_length_of(:title).is_at_most(40) }
+    it { is_expected.to validate_length_of(:description).is_at_most(255) }
+  end
+
+  context "正しいタスクを作成した時" do
+    it 'valid と返す' do
+      expect(task).to be_valid
+    end
+  end
+
+  context 'title が空白の時' do
+    it 'invalid と返す' do
+      task = build(:task, title: ' ' * 10)
+      expect(task).to_not be_valid
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Task, type: :model do
     it { is_expected.to validate_length_of(:description).is_at_most(255) }
   end
 
+  describe 'belongs_to' do
+    it { should belong_to(:user) }
+  end
+
   context "正しいタスクを作成した時" do
     it 'valid と返す' do
       expect(task).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,13 +46,7 @@ RSpec.describe User, type: :model do
   end
 
   describe 'has_many' do
-    describe 'User.tasks' do
-      it 'makes get a task' do
-        user = create(:user)
-        task = create(:task, user: user)
-        expect(user.tasks.first.id).to eq task.id
-      end
-    end
+    it { should have_many(:tasks) }
   end
 
   describe 'before_save' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_length_of(:password).is_at_least(6) }
   end
 
+  describe 'has_many' do
+    describe 'User.tasks' do
+      it 'makes get a task' do
+        user = create(:user)
+        task = create(:task, user: user)
+        expect(user.tasks.first.id).to eq task.id
+      end
+    end
+  end
+
   describe 'before_save' do
     describe '#email_downcase' do
       let!(:user) { create(:user, email: 'USER@EXAMPLE.COM') }


### PR DESCRIPTION
fixes #4 

## 背景
- ユーザーが予定を記録するための Task モデルが欲しい。
- Task モデルには以下の情報が登録できる
  - 予定のタイトル( title:string )
  - 詳細( description:text )
  - 開始時間 ( start_at:string )
  - 終了時間 ( finish_at:string )
  - タスク作成ユーザー ( user:references )

## やったこと
- [x] Task モデルの作成
- [x] Validation の追加
- [x] テストの作成



