### PR TITLE
Add task list to profile page

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,3 +110,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Style/PredicateName:
+  Enabled: false
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,4 +31,9 @@ class UsersController < ApplicationController
       :password_confirmation
     )
   end
+
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to root_path unless current_user?(@user)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,9 +31,4 @@ class UsersController < ApplicationController
       :password_confirmation
     )
   end
-
-  def correct_user
-    @user = User.find(params[:id])
-    redirect_to root_path unless current_user?(@user)
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,11 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @tasks = @user.tasks.first(5)
+    if is_current_user?(@user)
+      @tasks = @user.tasks.first(5)
+    else
+      redirect_to root_path, flash: { danger: '閲覧権限がありません。原則、他のユーザーのプロフィール情報は閲覧することができません。' }
+    end
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @tasks = @user.tasks.first(5)
   end
 
   def create

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,6 +12,10 @@ module SessionsHelper
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
+  def current_user?(user)
+    user == current_user
+  end
+
   def logged_in?
     !current_user.nil?
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,7 +12,7 @@ module SessionsHelper
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
-  def current_user?(user)
+  def is_current_user?(user)
     user == current_user
   end
 

--- a/app/javascript/stylesheets/users/_show.scss
+++ b/app/javascript/stylesheets/users/_show.scss
@@ -1,6 +1,6 @@
 .profile {
   margin: 3rem auto;
-  width: 450px;
+  max-width: 70%;
   h1 {
     font: {
       family: $font-primary;
@@ -26,5 +26,6 @@
   }
   .users-email {
     font-weight: 400;
+    margin-bottom: 2rem;
   }
 }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,46 +21,32 @@
         </header>
         <div class="card-content">
           <div class="content">
-            <% if current_user?(@user) %>
-              <%if @tasks.any? %>
-                <% @tasks.each do |task| %>
-                  <!-- TODO href: <タスクの詳細ページ get '/users/:id/tasks/:id', to: 'tasks#edit -->
-                  <%= link_to task.title %>
-                  <br>
-                  <%= task.description %>
-                  <br>
-                  start_at: <%= task.start_at %>
-                  finish_at: <%= task.finish_at %>
-                  <hr>
-                <% end %>
-                <div class="to-more-task-link has-text-right">
-                  <!-- TODO href: <タスク一覧のページ get '/users/:id/tasks', to: 'tasks#show' -->
-                  <%= link_to 'Show more ...' %>
-                </div>
-              <% else %>
-                <div class="message is-info">
-                  <div class="message-header">
-                    タスクがまだ作成されていません
-                  </div>
-                  <div class="message-body">
-                    タスクを登録すると、その日の自分の予定や、グループメンバーの予定が一覧で確認できます。さっそく新しいタスクを作成してみましょう！
-                    <hr>
-                    <%= link_to 'タスクを作成する' %>
-                  </div>
-                </div>
-              <% end %>
-            <% else %>
-            <div class="message is-warning">
-              <div class="message-header">
-                閲覧権限がありません
-              </div>
-              <div class="message-body">
-                原則、他のユーザーのタスクは閲覧できません。
-                同じグループに所属しており、グループメンバーに公開されているタスクであれば閲覧できます。
+            <%if @tasks.present? %>
+              <% @tasks.each do |task| %>
+                <!-- TODO href: <タスクの詳細ページ get '/users/:id/tasks/:id', to: 'tasks#edit -->
+                <%= link_to task.title %>
+                <br>
+                <%= task.description %>
+                <br>
+                start_at: <%= task.start_at %>
+                finish_at: <%= task.finish_at %>
                 <hr>
-                <%= link_to '所属しているグループを確認する' %>
+              <% end %>
+              <div class="to-more-task-link has-text-right">
+                <!-- TODO href: <タスク一覧のページ get '/users/:id/tasks', to: 'tasks#show' -->
+                <%= link_to 'Show more ...' %>
               </div>
-            </div>
+            <% else %>
+              <div class="message is-info">
+                <div class="message-header">
+                  タスクがまだ作成されていません
+                </div>
+                <div class="message-body">
+                  タスクを登録すると、その日の自分の予定や、グループメンバーの予定が一覧で確認できます。さっそく新しいタスクを作成してみましょう！
+                  <hr>
+                  <%= link_to 'タスクを作成する' %>
+                </div>
+              </div>
             <% end %>
           </div>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,44 @@
-<div class="profile has-text-centered">
-  <h1 class="is-size-3">Profile</h1>
-  <div class="users-image">
-    <% image_path = Faker::Avatar.image %>
-    <img src="<%= "#{image_path}" %>">
+<div class="profile columns">
+  <div class="user-info has-text-centered column">
+    <h1 class="is-size-3">Profile</h1>
+    <div class="users-image">
+      <% image_path = Faker::Avatar.image %>
+      <img src="<%= "#{image_path}" %>">
+    </div>
+    <div class="users-name is-size-4">
+      <span><%= @user.name %></span>
+    </div>
+    <div class="users-email is-size-4">
+      <span><%= @user.email %></span>
+    </div>
   </div>
-  <div class="users-name is-size-4">
-    <span><%= @user.name %></span>
-  </div>
-  <div class="users-email is-size-4">
-    <span><%= @user.email %></span>
+  <div class="users-tasks column">
+      <div class="card">
+        <header class="card-header">
+          <div class="card-header-title is-3">
+            My Tasks
+          </div>
+        </header>
+        <div class="card-content">
+          <div class="content">
+            <% if @user.tasks.any? %>
+              <% @tasks.each do |task| %>
+                <!-- TODO href: <タスクの詳細ページ get '/users/:id/tasks/:id', to: 'tasks#edit -->
+                <%= link_to task.title %>
+                <br>
+                <%= task.description %>
+                <br>
+                start_at: <%= task.start_at %>
+                finish_at: <%= task.finish_at %>
+                <hr>
+              <% end %>
+              <div class="to-more-task-link has-text-right">
+                <!-- TODO href: <タスク一覧のページ get '/users/:id/tasks', to: 'tasks#show' -->
+                <%= link_to 'Show more ...' %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="profile columns">
-  <div class="user-info has-text-centered column">
+  <div class="user-info has-text-centered column is-one-third">
     <h1 class="is-size-3">Profile</h1>
     <div class="users-image">
       <% image_path = Faker::Avatar.image %>
@@ -16,26 +16,51 @@
       <div class="card">
         <header class="card-header">
           <div class="card-header-title is-3">
-            My Tasks
+            Tasks
           </div>
         </header>
         <div class="card-content">
           <div class="content">
-            <% if @user.tasks.any? %>
-              <% @tasks.each do |task| %>
-                <!-- TODO href: <タスクの詳細ページ get '/users/:id/tasks/:id', to: 'tasks#edit -->
-                <%= link_to task.title %>
-                <br>
-                <%= task.description %>
-                <br>
-                start_at: <%= task.start_at %>
-                finish_at: <%= task.finish_at %>
-                <hr>
+            <% if current_user?(@user) %>
+              <%if @tasks.any? %>
+                <% @tasks.each do |task| %>
+                  <!-- TODO href: <タスクの詳細ページ get '/users/:id/tasks/:id', to: 'tasks#edit -->
+                  <%= link_to task.title %>
+                  <br>
+                  <%= task.description %>
+                  <br>
+                  start_at: <%= task.start_at %>
+                  finish_at: <%= task.finish_at %>
+                  <hr>
+                <% end %>
+                <div class="to-more-task-link has-text-right">
+                  <!-- TODO href: <タスク一覧のページ get '/users/:id/tasks', to: 'tasks#show' -->
+                  <%= link_to 'Show more ...' %>
+                </div>
+              <% else %>
+                <div class="message is-info">
+                  <div class="message-header">
+                    タスクがまだ作成されていません
+                  </div>
+                  <div class="message-body">
+                    タスクを登録すると、その日の自分の予定や、グループメンバーの予定が一覧で確認できます。さっそく新しいタスクを作成してみましょう！
+                    <hr>
+                    <%= link_to 'タスクを作成する' %>
+                  </div>
+                </div>
               <% end %>
-              <div class="to-more-task-link has-text-right">
-                <!-- TODO href: <タスク一覧のページ get '/users/:id/tasks', to: 'tasks#show' -->
-                <%= link_to 'Show more ...' %>
+            <% else %>
+            <div class="message is-warning">
+              <div class="message-header">
+                閲覧権限がありません
               </div>
+              <div class="message-body">
+                原則、他のユーザーのタスクは閲覧できません。
+                同じグループに所属しており、グループメンバーに公開されているタスクであれば閲覧できます。
+                <hr>
+                <%= link_to '所属しているグループを確認する' %>
+              </div>
+            </div>
             <% end %>
           </div>
         </div>

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -1,8 +1,10 @@
-def login(user)
-  post login_path, params: {
-    session: {
-      email: user.email,
-      password: user.password
-    }
-  }
+def login(user, options = {})
+  if options[:by_capybara]
+    visit login_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  else
+    post login_path, params: { session: { email: user.email, password: user.password } }
+  end
 end

--- a/spec/systems/users_profile_spec.rb
+++ b/spec/systems/users_profile_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'UsersProfile', type: :system do
+  let(:user) { create(:user) }
+
+  context 'ログインしていない時' do
+    it '/login にリダイレクトされる' do
+      visit user_path(user)
+      expect(current_path).to eq login_path
+    end
+  end
+
+  context 'ログインしている時' do
+    before do
+      login(user, by_capybara: true)
+    end
+
+    it 'プロフィールページが閲覧できる' do
+      visit user_path(user)
+      expect(current_path).to eq user_path(user)
+    end
+
+    it 'タスク一覧が閲覧できる' do
+      create(:task, user: user)
+      visit user_path(user)
+      expect(page).to have_content(user.tasks.first.title)
+    end
+
+    it '他の人のタスク一覧は閲覧できない' do
+      other_user = create(:user)
+      create(:task, user: other_user)
+      visit user_path(other_user)
+      expect(page).to_not have_content(other_user.tasks.first.title)
+    end
+  end
+end

--- a/spec/systems/users_profile_spec.rb
+++ b/spec/systems/users_profile_spec.rb
@@ -20,17 +20,22 @@ RSpec.describe 'UsersProfile', type: :system do
       expect(current_path).to eq user_path(user)
     end
 
+    it 'タスク未作成だと「タスクがまだ作成されていません」と表示される' do
+      visit user_path(user)
+      expect(page).to have_content 'タスクがまだ作成されていません'
+    end
+
     it 'タスク一覧が閲覧できる' do
       create(:task, user: user)
       visit user_path(user)
       expect(page).to have_content(user.tasks.first.title)
     end
 
-    it '他の人のタスク一覧は閲覧できない' do
+    it '他のユーザーだと「閲覧権限がありません」と表示される' do
       other_user = create(:user)
       create(:task, user: other_user)
       visit user_path(other_user)
-      expect(page).to_not have_content(other_user.tasks.first.title)
+      expect(page).to have_content '閲覧権限がありません'
     end
   end
 end


### PR DESCRIPTION
🎫  #9 

## 背景
- ユーザーは登録したタスクを自分のプロフィールページからも確認したい。
- とはいえすべてのタスクをプロフィールページに表示するのではなく、最新の5つだけ表示したい。
- 他のユーザーのタスクは見えない

## やったこと
- [x] ユーザーのプロフィールページにタスクを表示するようにした
- [x] 自分以外のユーザーの場合、タスクは閲覧できない。
- [x] デザインを調整した
- [x] テストを作成

## やらないこと
- プロフィールページに表示されているタスクのタイトルをクリックすると、そのタスクの詳細ページに飛ぶことができる
- プロフィールページに表示されているタスク一覧の下部にある [Show more...] をクリックすると、ユーザーが持っているすべてのタスクを確認するページに飛ぶことができる

