### PR TITLE
Add ignore case for rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,3 +110,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Style/PredicateName:
+  Enabled: false
+


### PR DESCRIPTION
## 背景

`Style/PredicateName` を `Enabled: false` にしたい。

## やったこと
- [x] Style/PredicateName を無効化